### PR TITLE
Dockerfile implementation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3
+
+# Environment variables
+ENV OBIESOURCETOKEN=<TOKEN GOES HERE>
+# Create directory
+RUN mkdir -p /usr/src/bot
+WORKDIR /usr/src/bot
+
+# Finish creating environment
+COPY . /usr/src/bot
+RUN pip3 install -r requirements.txt
+
+# Entry Point
+CMD ["python3", "./obiesourcebot.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3
-
+MAINTAINER Nghi Nguyen <nnguyen@oberlin.edu>
 # Environment variables
 ENV OBIESOURCETOKEN=<TOKEN GOES HERE>
 # Create directory


### PR DESCRIPTION
Apparently, I had trouble running the discord bot because I'm on windows. venv will put the python and pip executables inside a differently named folder "Scripts" instead of bin.
There are many nuances involved in fixing it for Windows. So far, the only way I've been able to run the bot is using Docker, which I have just written a fairly usable Dockerfile to build and run. Therefore, I think it's kind of necessary to have Docker, for me at least.
